### PR TITLE
Removes print keybindings

### DIFF
--- a/KeyBindings/akitchen.idekeybindings
+++ b/KeyBindings/akitchen.idekeybindings
@@ -8,6 +8,42 @@
 		<array>
 			<dict>
 				<key>Action</key>
+				<string>runPageLayout:</string>
+				<key>Alternate</key>
+				<string>NO</string>
+				<key>CommandID</key>
+				<string>Xcode.IDEKit.CmdDefinition.PageSetup</string>
+				<key>Group</key>
+				<string>File Menu</string>
+				<key>GroupID</key>
+				<string>Xcode.IDEKit.MenuDefinition.Main</string>
+				<key>GroupedAlternate</key>
+				<string>NO</string>
+				<key>Navigation</key>
+				<string>NO</string>
+				<key>Title</key>
+				<string>Page Setup…</string>
+			</dict>
+			<dict>
+				<key>Action</key>
+				<string>printDocument:</string>
+				<key>Alternate</key>
+				<string>NO</string>
+				<key>CommandID</key>
+				<string>Xcode.IDEKit.CmdDefinition.Print</string>
+				<key>Group</key>
+				<string>File Menu</string>
+				<key>GroupID</key>
+				<string>Xcode.IDEKit.MenuDefinition.Main</string>
+				<key>GroupedAlternate</key>
+				<string>NO</string>
+				<key>Navigation</key>
+				<string>NO</string>
+				<key>Title</key>
+				<string>Print…</string>
+			</dict>
+			<dict>
+				<key>Action</key>
 				<string>showInspectorWithChoiceFromSender:</string>
 				<key>Alternate</key>
 				<string>NO</string>


### PR DESCRIPTION
As I am fat fingered, I often try to print my code or look at the page setup when I really want to open a file.

This removes print and page setup keybindings to prevent my own consternation.

Signed-off-by: Tim Jarratt <t.jarratt@pivotal.io>